### PR TITLE
use app user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM gusdecool/httpd
 
+WORKDIR /app
 ENV PUBLIC_DIR /app/build
+
+#--------------------------------------------------------------------------------------------------
+# Install base package
+#--------------------------------------------------------------------------------------------------
 
 # APT update and install base package
 RUN apt-get update
@@ -16,6 +21,21 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install -y yarn
 
+#--------------------------------------------------------------------------------------------------
+# Create & use "app" user
+#
+# We didn't use "root", because package manager like "npm" and "composer" will not execute
+# some script like "npm run prepare" if we use "root" user.
+#--------------------------------------------------------------------------------------------------
+
+ENV USER_HOME_DIR /home/app
+
+RUN useradd -rm -d ${USER_HOME_DIR} -s /bin/bash -g root -G sudo -u 1000 app
+RUN chown app /app
+
+# From here, we switch user to "app"
+USER app
+
 # Skip Host verification for git
-RUN mkdir /root/.ssh/
-RUN echo "StrictHostKeyChecking no " > /root/.ssh/config
+RUN mkdir ${USER_HOME_DIR}/.ssh/
+RUN echo "StrictHostKeyChecking no " > ${USER_HOME_DIR}/.ssh/config

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is docker base image to run application that using Reactjs. This image have
 ## Requirements:
 
 1. The docker image is expecting the volume mounted to `/app` directory and the web public directory located at `/app/build`
+2. If you would like to sync your OS private key, you will need to put your private key in `/home/app/.ssh` dir in container.
 
 ## Docker commands
 


### PR DESCRIPTION
NPM have behaviour where if we run command as `root` user, NPM silently didn't run script command like `npm run prepare`. This causing issue for package that have script command.

And since Docker by default run using `root` user, we inherited this issue. On this PR, we fixed the issue by make docker not run as `root` user.